### PR TITLE
修复CountingHashSet实现中的bug

### DIFF
--- a/src/main/java/com/github/hcsp/inheritance/CountingSet.java
+++ b/src/main/java/com/github/hcsp/inheritance/CountingSet.java
@@ -14,11 +14,6 @@ public class CountingSet extends HashSet<Object> {
         return super.add(obj);
     }
 
-    @Override
-    public boolean addAll(Collection c) {
-        count += c.size();
-        return super.addAll(c);
-    }
 
     public int getCount() {
         return count;


### PR DESCRIPTION
addAll方法中会调用add方法导致count重复计算