### PR TITLE
删除掉覆盖的addAll方法，导致循环计算两遍

### DIFF
--- a/src/main/java/com/github/hcsp/inheritance/CountingSet.java
+++ b/src/main/java/com/github/hcsp/inheritance/CountingSet.java
@@ -11,14 +11,19 @@ public class CountingSet extends HashSet<Object> {
     @Override
     public boolean add(Object obj) {
         count++;
+        System.out.println(count);
         return super.add(obj);
     }
 
-    @Override
-    public boolean addAll(Collection c) {
-        count += c.size();
-        return super.addAll(c);
-    }
+//    @Override
+//    public boolean addAll(Collection c) {
+//        System.out.println(count);
+//        System.out.println("45679");
+//        count += c.size();
+//        System.out.println(count);
+//        System.out.println("执行");
+//        return super.addAll(c);
+//    }
 
     public int getCount() {
         return count;


### PR DESCRIPTION
<!--- 你要打开的这个Pull request(PR)的类型是？默认是题目解答，如果你正在修复当前的仓库的缺陷，请选择对应的类型 -->

- [x] 这个PR解答了当前仓库中的题目（机器人会自动判题并合并当前PR）
- [ ] 这个PR修复了当前仓库中的一些代码缺陷（机器人不会判题，而是由管理员来处理当前PR）

